### PR TITLE
Fix imports by adding package init

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,6 +15,13 @@ This project applies PyTorch to classify 14 thoracic diseases using the NIH Ches
 ## Results
 Work in progress.
 
+## Usage
+Install the required dependencies and run the training script from the repository root:
+
+```bash
+python -m src.main
+```
+
 ## Future Work
 - ONNX export
 - Quantization/pruning


### PR DESCRIPTION
## Summary
- make `src` a package so imports work
- document how to run the training script

## Testing
- `python -m py_compile $(git ls-files '*.py')`
- `python -m src.main` *(fails: No module named 'torch')*

------
https://chatgpt.com/codex/tasks/task_e_684464fb7d58832aa4b795fe72dca111